### PR TITLE
Fix typo in repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ The XML:DB API can be built as a Jar file. This is also used by eXist-db's imple
 Java 8 and Apache Maven 3.5.3+ is required to build the JAR file.
 
 ```
-$ git clone https://github.com/exist-db/xmldb-repo.git
-$ cd xmldb-repo
+$ git clone https://github.com/exist-db/xmldb-org.git
+$ cd xmldb-org
 $ mvn clean compile package
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # XML:DB Initiative for XML Databases
 
-This is a coversion to Git of the `xapi` module from the XML:DB CVS repositiory anonymous@a.cvs.sourceforge.net:/cvsroot/xmldb-org.
+This is a conversion to Git of the `xapi` module from the XML:DB CVS repositiory via `anonymous@a.cvs.sourceforge.net:/cvsroot/xmldb-org`.
 
 The original project and code can be found at https://sourceforge.net/projects/xmldb-org/
 
 
 ## Building for eXist-db
 
-The XML:DB API can be built as a Jar file. This is also used by eXist-db's implementation of the XML:DB API.
+The XML:DB API can be built as a JAR file. This is also used by eXist-db's implementation of the XML:DB API.
 
 Java 8 and Apache Maven 3.5.3+ is required to build the JAR file.
 
@@ -17,4 +17,4 @@ $ cd xmldb-org
 $ mvn clean compile package
 ```
 
-The jar file will be located in the `target/` folder.
+The JAR file will be located in the `target/` folder.


### PR DESCRIPTION
It's https://github.com/eXist-db/xmldb-org, not https://github.com/eXist-db/xmldb-repo.